### PR TITLE
Create extract_mac.sh for macOS

### DIFF
--- a/extract_mac.sh
+++ b/extract_mac.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+if [ -z "${1}" ]
+then
+	echo "no codename specified" >&2
+	echo "Usage: ${0} <CODENAME>" >&2
+	exit 1
+fi
+cd "$(dirname "$0")"
+CONFIGS=definitions
+DEF=sdm845-generic
+CONFIG="${CONFIGS}/${1}.txt"
+if ! [ -f "${CONFIG}" ]
+then
+	echo "warning: your model has no definition file, use default" >&2
+	CONFIG="${CONFIGS}/${DEF}.txt"
+	if ! [ -f "${CONFIG}" ]
+	then
+		echo "default definition file not found"
+		exit 1
+	fi
+fi
+while read -r line
+do
+	file="${line//$'\r'/}"
+	file="${file//'\'//}"
+	cp -vr ."${file}" output/
+done<"${CONFIG}"
+find output -type f -name '*.inf_'|while read -r line
+do mv -v "${line}" "${line//.inf_/.inf}"
+done


### PR DESCRIPTION
The original extract.sh has problems on macOS with the `file="${file//\\/\/}"` backslash to forwardslash renamer line and changing it to `file="${file//'\'//}"` seems to have fixed the issue. Would be better if someone on Linux tried if this one still works normally so that we could have only one extract file